### PR TITLE
Blender 2.8 Fixes

### DIFF
--- a/mesh_morpher280.py
+++ b/mesh_morpher280.py
@@ -1,0 +1,187 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+#Blender 2.80 Fix - Matt Wallace
+
+bl_info = {
+    "name": "Mesh Morpher",
+    "author": "Joshua Bogart",
+    "version": (1, 0),
+    "blender": (2, 80, 0),
+    "location": "View3D > Tool Shelf > Unreal Tools",
+    "description": "Based on the 3ds Max script created by Jonathan Lindquist at Epic Games for use in conjunction with Unreal Engine 4",
+    "warning": "This script stores data in a meshes UV layers and Vertex Colors. If storing 2 shape keys or 1 and the object's pivot location UV layers 2-4 will be overwritten while preserving layer 1, 4 or higher."
+    "If not storing either 2 shape keys or the object's pivot location layer 2 will also be preserved. If storing morph 2 normals object's vertex color layer will be overwritten",
+    "wiki_url": "",
+    "category": "Unreal Tools",
+    }
+
+import bpy
+import mathutils
+from bpy.types import Operator, Panel, PropertyGroup
+from bpy.props import BoolProperty, PointerProperty
+from mathutils import Vector
+
+#get shape key vertex offsets
+def buildOffsetList(obj, props):
+    offsetList = []
+    
+    originalVertPos = [v.co for v in obj.data.shape_keys.key_blocks[0].data]
+    targetVertPos1 = [v.co for v in obj.data.shape_keys.key_blocks[1].data]  
+    vertOffset1 = [targetVertPos1[i] - originalVertPos[i] for i in range(len(originalVertPos))]
+    offsetList.append(vertOffset1)
+    
+    if props.store_pivot_location == False and len(obj.data.shape_keys.key_blocks) > 2:
+        targetVertPos2 = [v.co for v in obj.data.shape_keys.key_blocks[2].data]
+        vertOffset2 = [targetVertPos2[i] - originalVertPos[i] for i in range(len(originalVertPos))]
+        offsetList.append(vertOffset2)
+        
+    else:
+        vertOffset2 = [obj.location for i in range(len(originalVertPos))]
+        offsetList.append(vertOffset2)
+    
+    return offsetList
+
+#store normals in vertex colors
+def packVertexColors(obj):
+    
+    morphNormals = [i for i in zip(*(iter(obj.data.shape_keys.key_blocks[1].normals_vertex_get()),)*3)]
+    
+    for id, normal in enumerate(morphNormals):
+        currentNormal = normal
+        currentNormal = ((currentNormal[0] + 1.0) * 0.5, ((currentNormal[1] * -1.0) + 1.0) * 0.5, (currentNormal[2] + 1.0) * 0.5, 0)
+        morphNormals[id] = currentNormal
+    
+    while len(obj.data.vertex_colors) < 1:
+        obj.data.vertex_colors.new()
+        
+    for poly in obj.data.polygons:
+        
+        for vertId, loopId in zip(poly.vertices, poly.loop_indices):
+            obj.data.vertex_colors[0].data[loopId].color = morphNormals[vertId]
+
+#store offsets in UVs
+def packUVs(obj, offsetList, props):
+    vertOffset1 = offsetList[0]
+    
+    if props.store_pivot_location == True or len(obj.data.shape_keys.key_blocks) > 2:
+        vertOffset2 = offsetList[1]
+    
+    while len(obj.data.uv_layers.items()) < 4:
+        obj.data.uv_layers.new()
+    
+    for poly in obj.data.polygons:
+    
+        for vertId, loopId in zip(poly.vertices, poly.loop_indices):
+            
+            if props.store_pivot_location == True or len(obj.data.shape_keys.key_blocks) > 2:
+                obj.data.uv_layers[1].data[loopId].uv = (vertOffset2[vertId][0], 1.0 - (vertOffset2[vertId][1] * -1.0))
+                obj.data.uv_layers[2].data[loopId].uv = (vertOffset2[vertId][2], 1.0 - vertOffset1[vertId][0])
+                obj.data.uv_layers[3].data[loopId].uv = (vertOffset1[vertId][1] * -1.0, 1.0 - vertOffset1[vertId][2])
+                
+            else:
+                obj.data.uv_layers[2].data[loopId].uv = (0.0, 1.0 - vertOffset1[vertId][0])
+                obj.data.uv_layers[3].data[loopId].uv = (vertOffset1[vertId][1] * -1.0, 1.0 - vertOffset1[vertId][2])
+    
+#called by operator on UI panel
+def main(context):
+    obj = context.object
+    props = context.scene.mesh_morpher_properties
+    
+    offsetList = buildOffsetList(obj, props)
+    packUVs(obj, offsetList, props)
+    
+    if props.store_morph1_normals == True:
+        packVertexColors(obj)
+
+#create property group for user options
+class UT_MeshMorpherProperties(PropertyGroup):
+    store_morph1_normals = BoolProperty(name = "Store Morph 1 Normals")
+    store_pivot_location = BoolProperty(name = "Store Pivot Location")
+        
+#create operator class for panel button
+class UT_OT_PackMorphTargetsOperator(Operator):
+    bl_label = "Pack Morph Targets"
+    bl_idname = "unreal_tools.pack_morph_targets"
+    
+    @classmethod
+    def poll(cls, context):
+        c = context
+        
+        return  len(c.selected_objects) > 0 and c.active_object.type == 'MESH' and c.mode == 'OBJECT'
+
+    def execute(self, context):
+        units = context.scene.unit_settings
+        
+        if units.system != 'METRIC' or round(units.scale_length, 2) != 0.01:
+            
+            self.report({'ERROR'}, "Scene units must be Metric with a Unit Scale of 0.01!")
+            
+            return {'CANCELLED'}
+        
+        elif not context.object.data.shape_keys or len(context.object.data.shape_keys.key_blocks) < 2:
+            
+            self.report({'ERROR'}, "Object needs additional shape keys!")
+            
+            return {'CANCELLED'}
+        
+        else:
+            main(context)
+            
+            return {'FINISHED'}
+        
+#create panel class for UI in object mode tool shelf
+class UT_PT_MeshMorpherPanel(Panel):
+    bl_label = "Mesh Morpher"
+    bl_idname = "ut_mesh_morpher_panel"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = "Unreal Tools"
+    
+    def draw(self, context):
+        scene = context.scene
+        layout = self.layout
+      
+        col = layout.column(align = True)
+        col.prop(scene.mesh_morpher_properties, property="store_morph1_normals")
+        col.prop(scene.mesh_morpher_properties, property="store_pivot_location")
+
+        row = layout.row()
+        row.scale_y = 1.5
+        row.operator("unreal_tools.pack_morph_targets")
+
+#create register functions for adding and removing script  
+
+classes = ( UT_PT_MeshMorpherPanel, UT_OT_PackMorphTargetsOperator, UT_MeshMorpherProperties ) 
+
+def register():
+    from bpy.utils import register_class
+    for cls in classes:
+    	register_class(cls)
+
+    bpy.types.Scene.mesh_morpher_properties = PointerProperty(type = UT_MeshMorpherProperties)
+    
+def unregister():
+    from bpy.utils import unregister_class
+    for cls in reversed(classes):
+        unregister_class(cls)
+
+    del bpy.types.Scene.mesh_morpher_properties
+    
+if __name__ == "__main__":
+    register()

--- a/vertex_animation280.py
+++ b/vertex_animation280.py
@@ -1,0 +1,206 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+#Blender 2.80 Fix - Matt Wallace
+
+bl_info = {
+    "name": "Vertex Animation",
+    "author": "Joshua Bogart",
+    "version": (1, 0),
+    "blender": (2, 80, 0),
+    "location": "View3D > Tool Shelf > Unreal Tools",
+    "description": "Based on the 3ds Max script created by Jonathan Lindquist at Epic Games for use in conjunction with Unreal Engine 4",
+    "warning": "Remember to keep vertex and frame count low neither should go above 8192",
+    "wiki_url": "",
+    "category": "Unreal Tools",
+    }
+
+import bpy
+import bmesh
+import mathutils
+from bpy.types import Operator, Panel
+from mathutils import Vector
+
+#gets mesh data from an object in world coordinates with modifiers and transforms applied
+def copyMeshData(data, object, newBmesh, scene, context):
+    depsgraph = context.evaluated_depsgraph_get()
+    meshData = object.evaluated_get(depsgraph).to_mesh()
+    
+    for vert in meshData.vertices:
+        vert.co = object.matrix_world @ vert.co
+    
+    newBmesh.from_mesh(meshData)
+    object.evaluated_get(depsgraph).to_mesh_clear()
+    
+    return newBmesh
+
+#creates a list of combined mesh data per frame from selected objects
+def buildMorphList(data, selectedObjects, scene, context):
+    morphList = []
+    
+    for frame in range(scene.frame_start, scene.frame_end + 1, scene.frame_step):
+        scene.frame_set(frame)
+        newBmesh = bmesh.new()
+        
+        for object in selectedObjects:
+            
+            if object.type == 'MESH':
+                copyMeshData(data, object, newBmesh, scene, context)
+        
+        newMesh = data.meshes.new("mesh")
+        newBmesh.to_mesh(newMesh)
+        newBmesh.free()
+        newMesh.calc_normals()
+        newMorph = data.objects.new("morph", newMesh) 
+        morphList.append(newMorph)
+        
+    return morphList
+
+#packs UVs for export mesh evenly spacing verts across V axis
+def packUVs(mesh):
+    numVerts = len(mesh.data.vertices)
+    
+    while len(mesh.data.uv_layers.items()) < 2:
+        mesh.data.uv_layers.new()
+
+    for poly in mesh.data.polygons:
+        
+        for vertId, loopId in zip(poly.vertices, poly.loop_indices):
+            currentPos = ((vertId + 0.5)/numVerts)
+            mesh.data.uv_layers[1].data[loopId].uv = (currentPos, (1/255) * 128)
+
+#create mesh to export from mesh data taken on the first frame
+def generateExportMesh(data, morphList, scene, context):
+    exportMesh = morphList[0].copy()
+    exportMesh.name = "Export_Mesh"
+    context.collection.objects.link(exportMesh)
+
+    return exportMesh
+
+#stores offsets for vertex coordinates and normals in world space from the morphList
+def buildMorphData(data, morphList):
+    offsetVertPos = []
+    morphNormals = []
+    
+    originalVertPos = [morphList[0].matrix_world @ vert.co for vert in morphList[0].data.vertices]
+    
+    for morph in reversed(morphList):
+        
+        for i, vert in enumerate(morph.data.vertices):
+            currentNormal = vert.normal @ morph.matrix_world
+            currentNormal = Vector([(currentNormal[0] + 1.0) * 0.5, ((currentNormal[1] * -1.0) + 1.0) * 0.5, (currentNormal[2] + 1.0) * 0.5])
+            morphNormals.extend(currentNormal)
+            morphNormals.append(1.0)
+            currentVertPos = (morph.matrix_world @ vert.co) - originalVertPos[i]
+            currentVertPos = Vector([currentVertPos[0], -1.0 * currentVertPos[1], currentVertPos[2]])
+            offsetVertPos.extend(currentVertPos)
+            offsetVertPos.append(1.0)
+
+        data.objects.remove(morph)
+
+    for mesh in data.meshes:
+        if mesh.users == 0:
+            data.meshes.remove(mesh)
+    
+    morphData = [offsetVertPos, morphNormals]
+    
+    return morphData
+    
+#create textures from morphData
+def bakeMorphData(data, exportMesh, scene, morphData):
+    size = [len(exportMesh.data.vertices), len(range(scene.frame_start, scene.frame_end + 1, scene.frame_step))]
+    
+    morphTexture = data.images.new(name = "morphs", width = size[0], height = size[1], alpha = True, float_buffer = True)
+    normalTexture = data.images.new(name = "normals", width = size[0], height = size[1], alpha = True)
+    
+    morphTexture.pixels = morphData[0]
+    normalTexture.pixels = morphData[1]
+
+#called by operator on UI panel            
+def main(context):
+    scene = context.scene
+    data = bpy.data
+    selectedObjects = context.selected_objects
+    
+    morphList = buildMorphList(data, selectedObjects, scene, context)    
+    exportMesh = generateExportMesh(data, morphList, scene, context)
+    packUVs(exportMesh)
+    morphData = buildMorphData(data, morphList)
+    bakeMorphData(data, exportMesh, scene, morphData)
+
+#create operator class for panel button    
+class UT_OT_ProcessMeshesOperator(Operator):
+    bl_label = "Process Animated Meshes"
+    bl_idname = "unreal_tools.process_anim_meshes"
+    
+    @classmethod
+    def poll(cls, context):
+        return True in [object.type == 'MESH' for object in context.selected_objects] and context.mode == 'OBJECT'
+    
+    def execute(self, context):
+        units = context.scene.unit_settings
+        
+        if units.system != 'METRIC' or round(units.scale_length, 2) != 0.01:
+            
+            self.report({'ERROR'}, "Scene units must be Metric with a Unit Scale of 0.01!")
+        
+            return {'CANCELLED'}
+                        
+        else:
+            main(context)
+            
+            return {'FINISHED'}
+
+#create panel class for UI in object mode tool shelf
+class UT_PT_VertexAnimPanel(Panel):
+    bl_label = "Vertex Animation"
+    bl_idname = "ut_vertex_anim_panel"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = "Unreal Tools"
+    bl_context = "objectmode"
+    
+    def draw(self, context):
+        scene = context.scene
+        layout = self.layout
+               
+        col = layout.column(align = True)
+        col.prop(scene, "frame_start")
+        col.prop(scene, "frame_end")
+        col.prop(scene, "frame_step")
+        
+        row = layout.row()
+        row.scale_y = 1.5
+        row.operator("unreal_tools.process_anim_meshes")
+
+#create register functions for adding and removing script
+
+classes = ( UT_OT_ProcessMeshesOperator, UT_PT_VertexAnimPanel )
+
+def register():
+    from bpy.utils import register_class
+    for cls in classes:
+        register_class(cls)
+    
+def unregister():
+    from bpy.utils import unregister_class
+    for cls in reversed(classes):
+        unregister_class(cls)
+    
+if __name__ == "__main__":
+    register()


### PR DESCRIPTION
First of all, thank you for making these tools available for Blender.. :} 

I've updated your code for Blender 2.80 release. I hope this helps.

Fixes include:
-class naming conventions ( '_PT_' and  '_OT_' prefixes ),
-updated register functions, 
-panel bl_region_type changed to 'UI',
-matrix multiplication now uses @ operator,
-fixes related to scene.objects.link(), object.to_mesh(), and mesh.data.uv_textures

Not backwards compatible, although support for this could be added in the future by checking bpy.app.version

-Matt W.