### PR TITLE
Update vertex_animation.py

### DIFF
--- a/vertex_animation.py
+++ b/vertex_animation.py
@@ -104,14 +104,21 @@ def bake_vertex_data(context, data, offsets, normals, size):
         alpha=True,
         float_buffer=True
     )
+    offset_texture.pixels = offsets
+    offset_texture.filepath_raw = "//offsets.exr"
+    offset_texture.file_format = 'OPEN_EXR'
+    offset_texture.save()
+
     normal_texture = data.images.new(
         name="normals",
         width=width,
         height=height,
         alpha=True
     )
-    offset_texture.pixels = offsets
     normal_texture.pixels = normals
+    normal_texture.filepath_raw = "//normals.bmp"
+    normal_texture.file_format = 'BMP'
+    normal_texture.save()
 
 
 class OBJECT_OT_ProcessAnimMeshes(bpy.types.Operator):


### PR DESCRIPTION
Added texture saving to fix blank/black textures in Blender 3.2+
<img width="1280" alt="Fix" src="https://user-images.githubusercontent.com/88483073/187176397-77273549-0f25-41ad-ba2e-15f014af4456.png">
